### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/java11-build.yml
+++ b/.github/workflows/java11-build.yml
@@ -3,6 +3,9 @@
 
 name: Java 11 PR
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [ main ]

--- a/.github/workflows/java11-publish.yml
+++ b/.github/workflows/java11-publish.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+  packages: write
 name: Publish JRE11 to the Maven Central
 on:
   release:

--- a/.github/workflows/java11-push.yml
+++ b/.github/workflows/java11-push.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
 name: Java 11 CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/filip26/carbon-decentralized-identifiers/security/code-scanning/3](https://github.com/filip26/carbon-decentralized-identifiers/security/code-scanning/3)

To address the problem, add a `permissions` block at the workflow level to restrict the permissions of the `GITHUB_TOKEN`. Based on the workflow's actions, it likely only requires `contents: read` permission to check out code using `actions/checkout` and minimal write permissions for actions related to publishing packages. We will assign `contents: read` and `packages: write` permissions, ensuring that unnecessary permissions are not granted.

The fix involves modifying the `.github/workflows/java11-publish.yml` file at the root level (before the `jobs` key) to include the `permissions` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
